### PR TITLE
Support GHC 8.8, bump bounds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,11 @@ sudo: true
 
 # Add new environments to the build here:
 env:
-  - GHCVER=8.0.2  CABALVER=2.4
-  - GHCVER=8.2.2  CABALVER=2.4
-  - GHCVER=8.4.4  CABALVER=2.4
-  - GHCVER=8.6.4  CABALVER=2.4
+  - GHCVER=8.0.2  CABALVER=3.0
+  - GHCVER=8.2.2  CABALVER=3.0
+  - GHCVER=8.4.4  CABALVER=3.0
+  - GHCVER=8.6.5  CABALVER=3.0
+  - GHCVER=8.8.3  CABALVER=3.0
   - GHCVER=head   CABALVER=head
 
 cache:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,8 @@ environment:
     - GHCVER: 8.0.2
     - GHCVER: 8.2.2
     - GHCVER: 8.4.4
-    - GHCVER: 8.6.4
+    - GHCVER: 8.6.5
+    - GHCVER: 8.8.3
 
 cache:
   - dist-newstyle

--- a/driver/Main.hs
+++ b/driver/Main.hs
@@ -1,6 +1,6 @@
 
 import Data.Version               ( showVersion )
-import System.Environment         ( getArgs, getProgName ) 
+import System.Environment         ( getArgs, getProgName )
 import System.Exit                ( die, exitSuccess )
 import System.Console.GetOpt
 

--- a/haddock-test/Main.hs
+++ b/haddock-test/Main.hs
@@ -24,7 +24,7 @@ options = [ Option []    ["accept"] (NoArg Accept) "accept the output"
 data Opt = Accept | Help deriving Eq
 
 main = do
-  
+
   -- Command line args: do we want to accept or not?
   args <- getArgs
   let header = "Usage: haddock-test [OPTION...]"
@@ -32,7 +32,7 @@ main = do
     (_, _, errs @ (_:_)) -> ioError (userError (concat errs                          ++ usageInfo header options))
     (_, non @ (_:_), []) -> ioError (userError ("Unexpected options: " ++ concat non ++ usageInfo header options))
     (opts, [], [])
-      | Help `elem` opts -> ioError (userError (                                        usageInfo header options)) 
+      | Help `elem` opts -> ioError (userError (                                        usageInfo header options))
       | Accept `elem` opts -> pure True
       | otherwise -> pure False
 
@@ -40,7 +40,7 @@ main = do
   srcs <- listDirectory ("haddock-test" </> "src")
   createDirectoryIfMissing True ("haddock-test" </> "out")
   createDirectoryIfMissing True ("haddock-test" </> "ref")
-  
+
   -- Run them in a loop
   for_ srcs $ \srcFile -> do
     putStrLn $ "Checking " ++ srcFile ++ "..."
@@ -51,14 +51,14 @@ main = do
 
     inp <- readFile src
     let output = renderString (layoutPretty defaultLayoutOptions (haddock2Doc inp))
-  
+
     -- Accept or test
     if accept
       then do writeFile ref output
       else do writeFile out output
               diff : _ <- catMaybes <$> traverse findExecutable ["colordiff", "diff"]
               callProcess diff ["--strip-trailing-cr", ref, out]
- 
+
   -- Report status
   putStrLn $ "All " <> show (length srcs) <> " test cases " <> if accept then "accepted." else "passed."
 

--- a/pretty-ghci.cabal
+++ b/pretty-ghci.cabal
@@ -27,7 +27,7 @@ extra-source-files:
   show-test/src/*.txt
   show-test/ref/*.txt
 
-tested-with:           GHC==8.0.2, GHC==8.2.2, GHC==8.4.4, GHC==8.6.4
+tested-with:           GHC==8.0.2, GHC==8.2.2, GHC==8.4.4, GHC==8.6.5, GHC==8.8.3
 
 executable pp-ghci
   main-is:             Main.hs
@@ -48,13 +48,13 @@ library
                        Text.PrettyPrint.GHCi.Value.Parser
                        System.Terminal.Utils
 
-  build-tools:         alex                        >=3.1
-                     , happy                       >=1.19
+  build-tool-depends:  alex:alex                   >=3.1
+                     , happy:happy                 >=1.19
 
-  build-depends:       base                        >=4.9 && <4.13
-                     , haddock-library             ^>=1.7
+  build-depends:       base                        >=4.9 && <4.15
+                     , haddock-library             ^>=1.8
                      , prettyprinter-ansi-terminal ^>=1.1
-                     , prettyprinter               ^>=1.2
+                     , prettyprinter               ^>=1.6
                      , text                        ^>=1.2
                      , array                       ^>=0.5
 

--- a/show-test/Main.hs
+++ b/show-test/Main.hs
@@ -33,7 +33,7 @@ main = do
     (_, _, errs @ (_:_)) -> ioError (userError (concat errs                          ++ usageInfo header options))
     (_, non @ (_:_), []) -> ioError (userError ("Unexpected options: " ++ concat non ++ usageInfo header options))
     (opts, [], [])
-      | Help `elem` opts -> ioError (userError (                                        usageInfo header options)) 
+      | Help `elem` opts -> ioError (userError (                                        usageInfo header options))
       | Accept `elem` opts -> pure True
       | otherwise -> pure False
 
@@ -41,7 +41,7 @@ main = do
   srcs <- listDirectory ("show-test" </> "src")
   createDirectoryIfMissing True ("show-test" </> "out")
   createDirectoryIfMissing True ("show-test" </> "ref")
-  
+
   -- Run them in a loop
   for_ srcs $ \srcFile -> do
     putStrLn $ "Checking " ++ srcFile ++ "..."
@@ -53,14 +53,14 @@ main = do
     setLocaleEncoding utf8
     inp <- readFile src
     let output = renderString (layoutPretty defaultLayoutOptions (value2Doc inp))
-  
+
     -- Accept or test
     if accept
       then do writeFile ref output
       else do writeFile out output
               diff : _ <- catMaybes <$> traverse findExecutable ["colordiff", "diff"]
               callProcess diff ["--strip-trailing-cr", ref, out]
- 
+
   -- Report status
   putStrLn $ "All " <> show (length srcs) <> " test cases " <> if accept then "accepted." else "passed."
 

--- a/src-unix/System/Terminal/Utils.hsc
+++ b/src-unix/System/Terminal/Utils.hsc
@@ -40,7 +40,7 @@ data WinSize = WinSize CUShort CUShort
 
 instance Storable WinSize where
   sizeOf _ = (#size struct winsize)
-  alignment _ = (#alignment struct winsize) 
+  alignment _ = (#alignment struct winsize)
   peek ptr = do
     row <- (#peek struct winsize, ws_row) ptr
     col <- (#peek struct winsize, ws_col) ptr

--- a/src/Text/PrettyPrint/GHCi.hs
+++ b/src/Text/PrettyPrint/GHCi.hs
@@ -3,7 +3,7 @@ module Text.PrettyPrint.GHCi (
   prettyPrintValue, value2Doc,
   ValuePrintConf(..),
   defaultValueConf,
- 
+
   -- * Interactive doc string printing
   prettyPrintHaddock, haddock2Doc,
   HaddockPrintConf(..),

--- a/src/Text/PrettyPrint/GHCi/Value.hs
+++ b/src/Text/PrettyPrint/GHCi/Value.hs
@@ -47,13 +47,13 @@ value2Doc shown = case parseValue shown of
 -- | A Good Enough colour scheme
 defaultValueConf :: ValuePrintConf
 defaultValueConf = ValuePrintConf
-  { vpc_number    = color Cyan 
+  { vpc_number    = color Cyan
   , vpc_character = color Blue
   , vpc_string    = color Green
   , vpc_control   = bold <> color Magenta
   , vpc_comma     = color Yellow
   , vpc_operator  = color White
-  , vpc_field     = italicized <> colorDull Red 
+  , vpc_field     = italicized <> colorDull Red
   , vpc_indent    = 2
   }
 
@@ -79,17 +79,17 @@ renderValue vpc = renderVal
       Num i -> num (fromString i)
       Char c -> char (fromString c)
       Str s -> string (fromString s)
-      
+
       List vs  -> renderSeq (ctrl "[") (map (align . renderVal) vs) (ctrl "]")
       Tuple vs -> renderSeq (ctrl "(") (map (align . renderVal) vs) (ctrl ")")
-      
+
       -- Either everything goes on one line or the constructor and args each
       -- start on a new line (with args indented)
       Prefix c [] -> fromString c
       Prefix c vs ->
         let args = map (align . renderVal) vs
         in fromString c <> group (nest n (line <> align (vsep args)))
-     
+
       -- Either everything goes on one line, or each argument gets its own
       -- line with operators at the beginning of the lines
       Infix arg0 ops ->
@@ -103,7 +103,7 @@ renderValue vpc = renderVal
                                                , ctrl "=", align (renderVal x) ])
                              (ctrl "{" : repeat (coma ",")) (N.toList vs)
         in fromString c <> group (nest n (line <> align (vcat fields) <+> ctrl "}"))
-      
+
       Paren x -> ctrl "(" <> align (renderVal x) <> ctrl ")"
 
     -- Haskell style formatting of sequence-like things, with the comma at the

--- a/src/Text/PrettyPrint/GHCi/Value/Lexer.x
+++ b/src/Text/PrettyPrint/GHCi/Value/Lexer.x
@@ -24,7 +24,7 @@ $hexit     = [$decdigit A-F a-f]
 @bin_exponent = @numspc [pP] [\-\+]? @decimal
 
 @floating_point = @numspc @decimal \. @decimal @exponent? | @numspc @decimal @exponent
-@hex_floating_point = ( @numspc @hexadecimal \. @hexadecimal @bin_exponent? 
+@hex_floating_point = ( @numspc @hexadecimal \. @hexadecimal @bin_exponent?
                       | @numspc @hexadecimal @bin_exponent
                       )
 
@@ -61,24 +61,24 @@ $sym_op_char  = ~[ $white \[ \] \( \) \{ \} \, \" \' \= ]
 tokens :-
 
     $white+        { WhiteTok }
-    
+
     "("            { const OpenParen }
     ")"            { const CloseParen }
-    
+
     "["            { const OpenBracket }
     "]"            { const CloseBracket }
-    
+
     "{"            { const OpenBrace }
     "}"            { const CloseBrace }
-    
+
     ","            { const Comma }
     "="            { const Equal }
-   
+
     @decimal       { NumberTok }
     @number        { NumberTok }
     @character     { CharacterTok }
     @string        { StringTok }
-    
+
     @sym_op        { operatorOrSymbol }
 
 {
@@ -88,7 +88,7 @@ tokens :-
 lexTokens :: String -> [Token]
 lexTokens = alexScanTokens
 
--- | Our somewhat simplified version of GHC Haskell tokens 
+-- | Our somewhat simplified version of GHC Haskell tokens
 data Token
   = WhiteTok      String
   | NumberTok     String
@@ -108,7 +108,7 @@ data Token
   | Equal
   deriving (Eq, Show)
 
--- | Classify a string as either an operator or an identifier 
+-- | Classify a string as either an operator or an identifier
 operatorOrSymbol :: String -> Token
 operatorOrSymbol str
   | all isOperatorLike str = OperatorTok str

--- a/src/Text/PrettyPrint/GHCi/Value/Parser.y
+++ b/src/Text/PrettyPrint/GHCi/Value/Parser.y
@@ -18,7 +18,7 @@ import qualified Data.List.NonEmpty as N
        character  { CharacterTok $$ }
        operator   { OperatorTok $$ }
        identifier { IdentifierTok $$ }
-       '('        { OpenParen } 
+       '('        { OpenParen }
        ')'        { CloseParen }
        '['        { OpenBracket }
        ']'        { CloseBracket }


### PR DESCRIPTION
Some routine cleanup:

  * bump bounds in cabal files
  * use newer `haddock-library`
  * update CI to test all GHC versions
  * remove trailing spaces in source files